### PR TITLE
Fix version numbers in installation requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,6 @@ setuptools.setup(
     zip_safe=False,
     python_requires='>=3.5',
     install_requires=(
-        'Django>=2.2,<=4.0',
+        'Django>=2.2',
     )
 )


### PR DESCRIPTION
The `install_requires` in `setup.py` should mention minimum requirements for this package only ([source](https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/#id5)).

Fixes #3.